### PR TITLE
Setup script

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,7 @@ end
 def dotfiles
   Dir.glob('*').select do |file|
     File.file?(file)
-  end - %w[Rakefile tags]
+  end - %w[Rakefile setup.sh tags]
 end
 
 def snippets

--- a/scripts/desktop.sh
+++ b/scripts/desktop.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+source "scripts/install/is_installed.sh"
+
+INSTALL_DIRECTORY=~/code/installs
+CHROME_DEB=google-chrome-stable_current_amd64.deb
+CHROME_URL=https://dl.google.com/linux/direct
+ZOOM_DEB=zoom_amd64.deb
+ZOOM_URL=https://zoom.us/client/latest
+
+function wget_install {
+  if ! is_installed $1 ; then
+    wget -P $INSTALL_DIRECTORY $2/$3
+    sudo apt install $INSTALL_DIRECTORY/$3
+  fi
+}
+
+wget_install google-chrome $CHROME_URL $CHROME_DEB
+wget_install zoom $ZOOM_URL $ZOOM_DEB

--- a/scripts/directories.sh
+++ b/scripts/directories.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+rm -df ~/Documents ~/Music ~/Pictures ~/Public ~/Templates ~/Videos
+mkdir -p ~/code/installs
+mkdir -p ~/.vim/UltiSnips
+mkdir -p ~/.tmuxinator

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+bash "scripts/install/apt.sh"
+bash "scripts/install/cargo.sh"
+bash "scripts/install/github.sh"
+bash "scripts/install/npm.sh"
+bash "scripts/install/script.sh"
+bash "scripts/install/snap.sh"
+bash "scripts/install/tmuxinator-fzf-start.sh"
+bash "scripts/install/vim.sh"

--- a/scripts/install/apt.sh
+++ b/scripts/install/apt.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+source "scripts/install/is_installed.sh"
+
+function apt_install {
+  if ! is_installed "${2:-$1}" ; then
+    sudo apt install -y $1
+  fi
+}
+
+apt_install curl
+apt_install fzf
+apt_install git
+apt_install htop
+apt_install npm
+apt_install rake
+apt_install rbenv
+apt_install ripgrep rg
+apt_install ruby-build
+apt_install tmux
+apt_install tmuxinator
+apt_install tree
+apt_install zsh

--- a/scripts/install/cargo.sh
+++ b/scripts/install/cargo.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+source "scripts/install/is_installed.sh"
+
+if ! is_installed cargo ; then
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+fi
+
+function cargo_install {
+  if ! is_installed "${2:-$1}" ; then
+    cargo install $1
+  fi
+}
+
+cargo_install bat
+cargo_install exa

--- a/scripts/install/github.sh
+++ b/scripts/install/github.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+function clone {
+  if [ ! -d $3 ]; then
+    echo "Cloning: ${2}/${1}"
+    git clone git@github.com:$2/$1.git $3 ${@:4}
+  else
+    echo "Already cloned: ${2}/${1}"
+  fi
+}
+
+clone asdf            asdf-vm      ~/.asdf             ; (cd  ~/.asdf; git checkout "$(git describe --abbrev=0 --tags)" &> /dev/null)
+clone bash-git-prompt magicmonty   ~/.bash-git-prompt  --depth=1
+clone tpm             tmux-plugins ~/.tmux/plugins/tpm ; tmux source   ~/.tmux.conf

--- a/scripts/install/is_installed.sh
+++ b/scripts/install/is_installed.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+function is_installed {
+  which $1 &> /dev/null
+
+  if [ $? -ne 0 ]; then
+    echo "Installing: ${1}"
+    return 1
+  else
+    echo "Already installed: ${1}"
+    return 0
+  fi
+}

--- a/scripts/install/npm.sh
+++ b/scripts/install/npm.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+source "scripts/install/is_installed.sh"
+
+function npm_install {
+  if ! is_installed "${2:-$1}" ; then
+    sudo npm install -g $1
+  fi
+}
+
+npm_install diff-so-fancy
+npm_install tldr

--- a/scripts/install/script.sh
+++ b/scripts/install/script.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+if [ ! -d /home/siggy/.oh-my-zsh ]; then
+  echo "Changing shell to zsh"
+  chsh -s $(which zsh)
+  echo "Installing: OhMyZsh"
+  sh -c "$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+else
+  echo "Shell is already zsh"
+  echo "Already installed: OhMyZsh"
+fi
+

--- a/scripts/install/snap.sh
+++ b/scripts/install/snap.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+source "scripts/install/is_installed.sh"
+
+function snap_install {
+  if ! is_installed "${2:-$1}" ; then
+    snap install $1
+  fi
+}
+
+snap_install slack
+snap_install spotify

--- a/scripts/install/tmuxinator-fzf-start.sh
+++ b/scripts/install/tmuxinator-fzf-start.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+source "scripts/install/is_installed.sh"
+
+TMUX_FZF=/usr/local/bin/tmuxinator-fzf-start.sh
+if ! is_installed tmuxinator-fzf-start.sh ; then
+  cd /usr/local/bin
+  sudo curl -O https://raw.githubusercontent.com/camspiers/tmuxinator-fzf-start/master/tmuxinator-fzf-start.sh
+  sudo chown siggy:siggy $TMUX_FZF
+  sudo chmod +x $TMUX_FZF
+  cd -
+fi

--- a/scripts/install/vim.sh
+++ b/scripts/install/vim.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+source "scripts/install/is_installed.sh"
+
+if ! is_installed vim ; then
+  # From https://gist.github.com/mkhuda/2e4c6f602786753aaa09c324ff47086e
+  sudo apt-get remove --purge vim vim-runtime vim-gnome vim-tiny vim-gui-common
+  sudo rm -rf /usr/local/share/vim /usr/bin/vim
+
+  sudo apt-get install gtk+-2.0 liblua5.1-dev luajit libluajit-5.1 python-dev python3-dev libperl-dev libncurses5-dev libatk1.0-dev libx11-dev libxpm-dev libxt-dev
+  cd ~/code/installs
+  git clone https://github.com/vim/vim
+  cd vim
+  git pull && git fetch
+
+  cd src
+  make distclean
+  cd ..
+
+  ./configure \
+    --enable-multibyte \
+    --enable-perlinterp=dynamic \
+    --enable-rubyinterp=dynamic \
+    --with-ruby-command=/home/$USER/.rbenv/shims/ruby \
+    --enable-python3interp \
+    --with-python3-command=python3.8
+    --with-python3-config-dir=/usr/lib/python3.8/config-3.8-x86_64-linux-gnu/ \
+    --enable-luainterp \
+    --with-luajit \
+    --enable-cscope \
+    --enable-gui=auto \
+    --with-features=huge \
+    --with-x \
+    --enable-fontset \
+    --enable-largefile \
+    --disable-netbeans \
+    --with-compiledby="siggy" \
+    --enable-fail-if-missing
+
+  make && sudo make install
+fi

--- a/scripts/keys.sh
+++ b/scripts/keys.sh
@@ -1,0 +1,15 @@
+#/usr/bin/env bash
+
+SSH_KEY=~/.ssh/id_rsa
+if [ ! -f $SSH_KEY ]; then
+  echo "Generating ssh key"
+  ssh-keygen -t rsa -b 4096 -N "" -f $SSH_KEY -C "michael@procore.com"
+  printf %.s= {1..100}
+  echo
+  cat $SSH_KEY.pub
+  printf %.s= {1..100}
+  echo
+  read -p "Visit https://github.com/settings/keys to enter key"
+else
+  echo "SSH key already exists"
+fi

--- a/scripts/settings.sh
+++ b/scripts/settings.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+gsettings set org.gnome.desktop.input-sources xkb-options   "['caps:ctrl_modifier']"
+gsettings set org.gnome.desktop.interface     clock-format  12h
+gsettings set org.gnome.shell                 favorite-apps "['google-chrome.desktop', 'slack.desktop', 'org.gnome.Terminal.desktop', 'spotify_spotify.desktop', 'org.gnome.Nautilus.desktop']"

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+PLUGIN_DIR="$(rbenv root)"/plugins
+RUBY_BUILD=$PLUGIN_DIR/ruby-build
+if [ ! -d $RUBY_BUILD ]; then
+  echo "Installing: ruby-build"
+  mkdir -p $PLUGIN_DIR
+  git clone git@github.com:rbenv/ruby-build.git $RUBY_BUILD
+  read -p "Select ruby version: " ruby_version
+  rbenv install $ruby_version
+  rbenv global $ruby_version
+else
+  echo "Already installed: ruby-build"
+fi
+
+asdf list postgres &> /dev/null
+if [ $? -ne 0 ]; then
+  echo "Installing: postgres"
+  read -p "Select pg version: " pg_version
+  asdf plugin add postgres
+  asdf install postgres $pg_version
+  asdf global postgres $pg_version
+else
+  echo "Already installed: postgres"
+fi

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# TODO
+# Better output
+# Introduce a curl script to do full setup
+
+set -e
+
+sudo apt -qq update
+
+bash "scripts/desktop.sh"
+bash "scripts/directories.sh"
+bash "scripts/keys.sh"
+bash "scripts/install.sh"
+bash "scripts/settings.sh"
+bash "scripts/versions.sh"
+
+(cd ~/code/dotfiles && rake install)
+
+sudo apt -qq upgrade -y
+sudo apt -qq autoremove -y

--- a/setup.sh
+++ b/setup.sh
@@ -6,7 +6,20 @@
 
 set -e
 
+DOTFILES_PATH=~/code/dotfiles
+if [ -d $DOTFILES_PATH ]; then
+  INITIAL_SETUP=1
+else
+  INITIAL_SETUP=0
+fi
+
 sudo apt -qq update
+
+if [ $INITIAL_SETUP -eq 0 ]; then
+  mkdir -p ~/code
+  git clone https://github.com/siegfault/dotfiles.git $DOTFILES_PATH
+fi
+cd $DOTFILES_PATH
 
 bash "scripts/desktop.sh"
 bash "scripts/directories.sh"
@@ -15,7 +28,11 @@ bash "scripts/install.sh"
 bash "scripts/settings.sh"
 bash "scripts/versions.sh"
 
-(cd ~/code/dotfiles && rake install)
+rake install
+
+if [ $INITIAL_SETUP -eq 0 ]; then
+  git remote set-url origin git@github.com/siegfault/dotfiles.git
+fi
 
 sudo apt -qq upgrade -y
 sudo apt -qq autoremove -y


### PR DESCRIPTION
Taking heavy inspiration from this great blog post
(https://victoria.dev/blog/how-to-set-up-a-fresh-ubuntu-desktop-using-only-dotfiles-and-bash-scripts/),
this _should_ allow me to go from scratch on a fresh ubuntu system to
complete setup simply by running ./setup.sh within my dotfiles (okay,
yes, I need to clone those first... maybe I can automate that as well?).

This sets things up by installation method (apt-get, cargo, cloning,
etc.) mainly. What isn't super clear from the code are the dependencies.
Some include
* Needs chrome to be installed before we try to paste a key to github
* OhMyZsh is installed in script.sh, which works because zsh is
  installed in apt.sh. Because they're alphabetical that works, but...
  gross.